### PR TITLE
Add Support for forceSingleSpacing as a config option

### DIFF
--- a/examples/single-spacing.html
+++ b/examples/single-spacing.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Treat linebreaks as single spaces</title>
+  <!-- include jquery -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+
+  <!-- include libraries BS -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+
+  <!-- include summernote -->
+  <script type="text/javascript" src="/summernote-bs4.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 200,
+        tabsize: 2,
+        forceSingleSpacing: true
+      })
+    });
+  </script>
+</head>
+<body>
+<textarea class="summernote"></textarea>
+</body>
+</html>

--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -1138,6 +1138,7 @@ export default {
   blank: blankHTML,
   /** @property {String} emptyPara */
   emptyPara: `<p>${blankHTML}</p>`,
+  emptyDiv: `<div>${blankHTML}</div>`,
   makePredByNodeName,
   isEditable,
   isControlSizing,

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -530,7 +530,7 @@ class WrappedRange {
 
       // wrap with paragraph
       if (inlineSiblings.length) {
-        const para = dom.wrap(lists.head(inlineSiblings), 'p');
+        const para = dom.wrap(lists.head(inlineSiblings), singleSpace ? 'div' : 'p');
         dom.appendChildNodes(para, lists.tail(inlineSiblings));
       }
     }

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -495,9 +495,9 @@ class WrappedRange {
    *
    * @return {WrappedRange}
    */
-  wrapBodyInlineWithPara() {
+  wrapBodyInlineWithPara(singleSpace=false) {
     if (dom.isBodyContainer(this.sc) && dom.isEmpty(this.sc)) {
-      this.sc.innerHTML = dom.emptyPara;
+      this.sc.innerHTML = singleSpace ? dom.emptyDiv : dom.emptyPara;
       return new WrappedRange(this.sc.firstChild, 0, this.sc.firstChild, 0);
     }
 

--- a/src/js/editing/Typing.js
+++ b/src/js/editing/Typing.js
@@ -42,14 +42,14 @@ export default class Typing {
    *   1 - Break the first blockquote in the ancestors list
    *   2 - Break all blockquotes, so that the new paragraph is not quoted (this is the default)
    */
-  insertParagraph(editable, rng) {
+  insertParagraph(editable, rng, singleSpace=false) {
     rng = rng || range.create(editable);
 
     // deleteContents on range.
     rng = rng.deleteContents();
 
     // Wrap range if it needs to be wrapped by paragraph
-    rng = rng.wrapBodyInlineWithPara();
+    rng = rng.wrapBodyInlineWithPara(singleSpace);
 
     // finding paragraph
     const splitRoot = dom.ancestor(rng.sc, dom.isPara);
@@ -72,7 +72,7 @@ export default class Typing {
 
         if (blockquote) {
           // We're inside a blockquote and options ask us to break it
-          nextPara = $(dom.emptyPara)[0];
+          nextPara = singleSpace ? $(dom.emptyDiv)[0] : $(dom.emptyPara)[0];
           // If the split is right before a <br>, remove it so that there's no "empty line"
           // after the split in the new blockquote created
           if (dom.isRightEdgePoint(rng.getStartPoint()) && dom.isBR(rng.sc.nextSibling)) {
@@ -97,14 +97,14 @@ export default class Typing {
 
           // replace empty heading, pre or custom-made styleTag with P tag
           if ((dom.isHeading(nextPara) || dom.isPre(nextPara) || dom.isCustomStyleTag(nextPara)) && dom.isEmpty(nextPara)) {
-            nextPara = dom.replace(nextPara, 'p');
+            nextPara = dom.replace(nextPara, singleSpace ? 'p' : 'div');
           }
         }
       }
     // no paragraph: insert empty paragraph
     } else {
       const next = rng.sc.childNodes[rng.so];
-      nextPara = $(dom.emptyPara)[0];
+      nextPara = singleSpace ? $(dom.emptyDiv)[0] : $(dom.emptyPara)[0];
       if (next) {
         rng.sc.insertBefore(nextPara, next);
       } else {

--- a/src/js/editing/Typing.js
+++ b/src/js/editing/Typing.js
@@ -97,7 +97,7 @@ export default class Typing {
 
           // replace empty heading, pre or custom-made styleTag with P tag
           if ((dom.isHeading(nextPara) || dom.isPre(nextPara) || dom.isCustomStyleTag(nextPara)) && dom.isEmpty(nextPara)) {
-            nextPara = dom.replace(nextPara, singleSpace ? 'p' : 'div');
+            nextPara = dom.replace(nextPara, singleSpace ? 'div' : 'p');
           }
         }
       }

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -405,7 +405,7 @@ export default class Editor {
     }
 
     // init content before set event
-    let initialWrapper = this.options.forceSingleSpacing ? dom.emptyDiv : dom.eptyPara;
+    const initialWrapper = this.options.forceSingleSpacing ? dom.emptyDiv : dom.eptyPara;
     this.$editable.html(dom.html(this.$note) || initialWrapper);
 
     this.$editable.on(env.inputEventName, func.debounce(() => {

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -96,7 +96,7 @@ export default class Editor {
     }
 
     this.insertParagraph = this.wrapCommand(() => {
-      this.typing.insertParagraph(this.editable);
+      this.typing.insertParagraph(this.editable, null, this.options.forceSingleSpacing);
     });
 
     this.insertOrderedList = this.wrapCommand(() => {
@@ -405,7 +405,7 @@ export default class Editor {
     }
 
     // init content before set event
-    this.$editable.html(dom.html(this.$note) || dom.emptyPara);
+    this.$editable.html(dom.html(this.$note) || this.options.forceSingleSpacing ? dom.emptyDiv : dom.emptyPara);
 
     this.$editable.on(env.inputEventName, func.debounce(() => {
       this.context.triggerEvent('change', this.$editable.html(), this.$editable);

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -405,7 +405,8 @@ export default class Editor {
     }
 
     // init content before set event
-    this.$editable.html(dom.html(this.$note) || this.options.forceSingleSpacing ? dom.emptyDiv : dom.emptyPara);
+    let initialWrapper = this.options.forceSingleSpacing ? dom.emptyDiv : dom.eptyPara;
+    this.$editable.html(dom.html(this.$note) || initialWrapper);
 
     this.$editable.on(env.inputEventName, func.debounce(() => {
       this.context.triggerEvent('change', this.$editable.html(), this.$editable);

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -122,6 +122,7 @@ $.summernote = $.extend($.summernote, {
     width: null,
     height: null,
     linkTargetBlank: true,
+    forceSingleSpacing: false,
 
     focus: false,
     tabDisable: false,

--- a/test/base/editing/Typing.spec.js
+++ b/test/base/editing/Typing.spec.js
@@ -21,12 +21,29 @@ describe('base:editing.Style', () => {
 
   describe('base:editing.Typing', () => {
     describe('insertParagraph', () => {
+      describe('single spacing', () => {
+        var $editable;
+
+        function check(html) {
+          expect($editable.html()).to.equalsIgnoreCase(html);
+        };
+
+        beforeEach(() => {
+          $editable = $('<div class="note-editable"><div>Part1</div></div>');
+        });
+
+        it('should insert new div instead of a p', () => {
+          typing(0).insertParagraph($editable, range.create($($editable)[0].firstChild, 6), true);
+          check('<div>Part1</div><div><br></div>');
+        });
+      });
+
       describe('blockquote breaking support', () => {
         var $editable;
 
         function check(html) {
           expect($editable.html()).to.equalsIgnoreCase(html);
-        }
+        };
 
         beforeEach(() => {
           $editable = $('<div class="note-editable"><blockquote id="1">Part1<blockquote id="2">Part2.1<br>Part2.2</blockquote>Part3</blockquote></div>');


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- Adds Support for forceSingleSpacing as a config option

#### Where should the reviewer start?

- src/js/editing/Typing.js conains the majority of the core changes, see the newly added example file for usage

#### How should this be manually tested?

- Initialize summernote without the config option, test as normal
- Initialize summernote with the `forceSingleSpacing: true` config option and test to ensure `div` is used instead of `p` on enter when editng.

#### Any background context you want to provide?

- I made an intentional choice to go with `div` tags instead of inserting `br` to maintain usage of a block-level wrapper, provide more styling flexibility, and mimic the behavior of common web-based email editros such as Gmail.

#### What are the relevant tickets?


#### Screenshot (if for frontend)
![Editor](https://kellishaver.com/drops/1714401347.png)
![Generated Source](https://kellishaver.com/drops/1714401408.png)

### Checklist

- [x] Added relevant tests or not required
- [ x Didn't break anything
